### PR TITLE
Disable PK printing to console

### DIFF
--- a/src/main/java/com/vechain/thorclient/console/Main.java
+++ b/src/main/java/com/vechain/thorclient/console/Main.java
@@ -65,7 +65,8 @@ public class Main {
 			} else if (args[0].equals(BLOCK_REF)) {
 				BlockchainQueryConsole.getBestBlockRef();
 			} else if (args[0].equals(CREATE_WALLET)) {
-				WalletConsole.createWalletToKeystoreFile(args);
+				System.out.println("This feature is deprecated");
+				//WalletConsole.createWalletToKeystoreFile(args);
 			} else if (args[0].equals(SEND)) {
 				// args=signAndSendVET {providerUrl} {privateKey} {filePath}
 				TransactionConsole.sendTransactionFromCSVFile(args, privateKey);

--- a/src/main/java/com/vechain/thorclient/console/Main.java
+++ b/src/main/java/com/vechain/thorclient/console/Main.java
@@ -65,8 +65,7 @@ public class Main {
 			} else if (args[0].equals(BLOCK_REF)) {
 				BlockchainQueryConsole.getBestBlockRef();
 			} else if (args[0].equals(CREATE_WALLET)) {
-				System.out.println("This feature is deprecated");
-				//WalletConsole.createWalletToKeystoreFile(args);
+				WalletConsole.createWalletToKeystoreFile(args);
 			} else if (args[0].equals(SEND)) {
 				// args=signAndSendVET {providerUrl} {privateKey} {filePath}
 				TransactionConsole.sendTransactionFromCSVFile(args, privateKey);

--- a/src/main/java/com/vechain/thorclient/console/WalletConsole.java
+++ b/src/main/java/com/vechain/thorclient/console/WalletConsole.java
@@ -19,7 +19,6 @@ public class WalletConsole {
 	 *            createWallet password path(options)
 	 * @throws IOException
 	 */
-	@Deprecated
 	public static void createWalletToKeystoreFile(String[] args) throws IOException {
 		if (args.length < 2) {
 			System.out.println("You have input invalid parameters.");

--- a/src/main/java/com/vechain/thorclient/console/WalletConsole.java
+++ b/src/main/java/com/vechain/thorclient/console/WalletConsole.java
@@ -14,7 +14,7 @@ public class WalletConsole {
 
 	/**
 	 * createWalletToKeystoreFile
-	 * 
+	 *
 	 * @param args
 	 *            createWallet password path(options)
 	 * @throws IOException
@@ -42,7 +42,5 @@ public class WalletConsole {
 		out.close();
 		System.out.println("The wallet created successfully and the key store is:");
 		System.out.println(keyStoreStr);
-		System.out.println("The wallet created successfully and the privateKey is:");
-		System.out.println(newPrivateKey);
 	}
 }

--- a/src/main/java/com/vechain/thorclient/console/WalletConsole.java
+++ b/src/main/java/com/vechain/thorclient/console/WalletConsole.java
@@ -19,6 +19,7 @@ public class WalletConsole {
 	 *            createWallet password path(options)
 	 * @throws IOException
 	 */
+	@Deprecated
 	public static void createWalletToKeystoreFile(String[] args) throws IOException {
 		if (args.length < 2) {
 			System.out.println("You have input invalid parameters.");


### PR DESCRIPTION
When creating a keystore file, the private key was being printed to console
The feature to create a keystore remains, just printing its PK to console is removed
