### PR TITLE
chore(deps): bump jackson, bouncycastle and logback to clear security alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,19 +22,19 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.15</version>
+            <version>1.3.16</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.3.15</version>
+            <version>1.3.16</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.1</version>
         </dependency>
 
         <dependency>
@@ -52,19 +52,19 @@
         <dependency>
             <groupId>io.mikael</groupId>
             <artifactId>urlbuilder</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.85.2</version>
         </dependency>
 
         <dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Clears **8 of the 11** open Dependabot alerts, including the critical and both highs. Every bumped version is verified Java 8 bytecode, so the Java 8 floor is unchanged.

| Dependency | From | To | Alerts cleared |
|---|---|---|---|
| `jackson-databind` | 2.19.0 | 2.22.1 | 2 high, 3 medium |
| `bcprov-jdk18on` | 1.80 | 1.85.2 | **1 critical**, 1 medium |
| `logback` core/classic | 1.3.15 | 1.3.16 | 1 medium |
| `poi-ooxml` | 5.4.0 | 5.5.1 | — |
| `urlbuilder` | 2.0.7 | 2.0.9 | — |
| `junit` | 4.13.1 | 4.13.2 | — |

**Deliberately not bumped:** `blake2b` 1.0.0 → 2.0.0 is a major version, and `CryptoUtils.blake2b` derives VeChain transaction IDs. That needs known-answer vectors, not a routine bump.

**The 3 remaining alerts** are all low and need logback 1.5.x, which requires Java 11. All three are deserialization issues reachable only via logback's socket-receiver components — this SDK ships no logback configuration and uses no such appenders, so they aren't reachable here.

**Verification**
- JDK 8 against thor solo: 94 tests, 0 failures, matching the pre-change baseline
- The bouncycastle bump touches signing, so it was additionally diffed against 1.80 with a fixed key and message. Derived address, compressed and uncompressed public keys, and the ECDSA `r`/`s`/`v` are **byte-identical** across both versions
- Merges cleanly with #73 (verified by trial merge), so it can land independently of that stack
