### PR TITLE
chore: fix javadoc, correct documented coordinates, add dependency guardrails and release assets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  # Maven dependencies. Grouped so routine patch/minor bumps arrive as one PR
+  # rather than one per artifact, which is how the previous batch went stale.
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      maven-patch-and-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Pinned to the Java 8 line. logback 1.5+ and 1.6+ require Java 11, so a
+      # major bump here would silently break the SDK's baseline.
+      - dependency-name: "ch.qos.logback:*"
+        update-types: ["version-update:semver-major"]
+      # 2.0.0 is compiled for Java 9 and cannot load on Java 8. It also derives
+      # VeChain transaction IDs, so any bump needs known-answer hash vectors.
+      - dependency-name: "com.rfksystems:blake2b"
+    labels:
+      - dependencies
+
+  # Workflow actions are currently several majors behind (checkout@v3,
+  # setup-java@v3), which Dependabot does not track without this entry.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - dependencies

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ jobs:
   build-and-deploy-release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -35,6 +38,14 @@ jobs:
         run: mvn deploy -Pall
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Without this the release ships no downloadable artifact: v0.1.0 and v0.1.1
+      # both published zero assets, so the runnable CLI jar was unobtainable
+      # except by building from source.
+      - name: Attach runnable jar to the release
+        run: gh release upload "${GITHUB_REF#refs/tags/}" target/*-with-dependencies.jar --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Stop solo
         run: make solo-down  

--- a/docs/MAIN_DOCUMENTATION.md
+++ b/docs/MAIN_DOCUMENTATION.md
@@ -17,13 +17,30 @@
 ## Quick Start
 
 ### Maven Dependency
+
 ```xml
 <dependency>
-    <groupId>com.vechain</groupId>
+    <groupId>com.vechain.client</groupId>
     <artifactId>thor-client-sdk4j</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 </dependency>
 ```
+
+The artifact is published to GitHub Packages, not Maven Central, so the
+repository must also be declared:
+
+```xml
+<repositories>
+    <repository>
+        <id>github</id>
+        <url>https://maven.pkg.github.com/vechain/thor-client-sdk4j</url>
+    </repository>
+</repositories>
+```
+
+GitHub Packages requires authentication even for public artifacts, so a
+matching `<server>` entry with a personal access token (`read:packages`
+scope) is needed in your `~/.m2/settings.xml`.
 
 ### Basic Setup
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,36 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.9.0</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>enforce-java8-bytecode</id>
+                        <!-- validate, not verify: CI runs `mvn test`, which never reaches
+                             the verify phase, so the guard would otherwise never fire. -->
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>1.8</maxJdkVersion>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.0</version>
                 <executions>

--- a/src/main/java/com/vechain/thorclient/clients/AccountClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/AccountClient.java
@@ -105,7 +105,7 @@ public class AccountClient extends AbstractClient {
      * @param contractCall {@link ContractCall}
      * @return {@link ContractCallResult}
      * @throws ClientIOException if network error or invalid request.
-     * @Deprecated please use {@link AccountClient.performAccountCall} instead.
+     * @see #performAccountCall(Revision, AccountCall)
      */
     @Deprecated
     public static ContractCallResult deployContractInfo(ContractCall contractCall) throws ClientIOException {

--- a/src/main/java/com/vechain/thorclient/clients/ERC20ContractClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/ERC20ContractClient.java
@@ -44,7 +44,7 @@ import java.util.ArrayList;
  *     ERC20Token.VTHO,
  *     null
  * );
- * System.out.println("VTHO Balance: " + balance.getDecimalAmount());
+ * System.out.println("VTHO Balance: " + balance.getAmount());
  * 
  * // Transfer VTHO tokens (EIP-1559)
  * TransferResult result = ERC20ContractClient.transferERC20Token(

--- a/src/main/java/com/vechain/thorclient/clients/ERC20ContractClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/ERC20ContractClient.java
@@ -83,7 +83,7 @@ public class ERC20ContractClient extends TransactionClient {
      * @throws ClientIOException if there's a network error or the contract call fails
      * 
      * @see ERC20Token#VTHO
-     * @see Amount#getDecimalAmount()
+     * @see Amount#getAmount()
      * @see Revision#BEST
      */
     public static Amount getERC20Balance(Address address, ERC20Token token, Revision revision)

--- a/src/main/java/com/vechain/thorclient/clients/ProtoTypeContractClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/ProtoTypeContractClient.java
@@ -14,7 +14,7 @@ import com.vechain.thorclient.utils.crypto.ECKeyPair;
 /**
  * ProtoType Contract is a native contract for user to do multiple parties payment(mpp).
  * <a href="https://github.com/vechain/thor/wiki/Prototype(CN)">Prototype</a>
- * <br>What is ProtoType for?</br>
+ * <br>What is ProtoType for?
  *
  * In common scenario, if a sender A want to make a transaction to target B,
  * the sender A need to pay the transaction fee(gas).
@@ -25,7 +25,7 @@ import com.vechain.thorclient.utils.crypto.ECKeyPair;
  * After all the things is done, then the sender A do transaction to target B, if the fee is less than the credit,
  * the ProtoType native contract is going to book fee(gas) from target B's account.
  *
- * <br>How to use ProtoType?</br>
+ * <br>How to use ProtoType?
  * First, you must be the master of the to address. By call {@link #setMasterAddress}, then you can query the master by
  * {@link #getMasterAddress(Address, Revision)}
  *

--- a/src/main/java/com/vechain/thorclient/clients/base/AbstractClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/base/AbstractClient.java
@@ -131,7 +131,7 @@ public abstract class AbstractClient {
      * @param tClass      the class of result java object.
      * @param <T>         Type of result java object.
      * @return response java object, could be null, mean cannot find any result.
-     * @throws IOException if the node is not reachable or the request is not valid.
+     * @throws ClientIOException if the node is not reachable or the request is not valid.
      */
     public static <T> T sendGetRequest(
             final Path path,

--- a/src/main/java/com/vechain/thorclient/core/model/blockchain/Account.java
+++ b/src/main/java/com/vechain/thorclient/core/model/blockchain/Account.java
@@ -36,8 +36,8 @@ public class Account implements Serializable {
     }
 
     /**
-     * Get VET token {@link Balance} object
-     * @return
+     * Get VET token balance.
+     * @return {@link Amount} the VET balance.
      */
     public Amount VETBalance(){
         Amount balance = Amount.createFromToken( AbstractToken.VET );

--- a/src/main/java/com/vechain/thorclient/core/model/clients/Amount.java
+++ b/src/main/java/com/vechain/thorclient/core/model/clients/Amount.java
@@ -30,7 +30,7 @@ import com.vechain.thorclient.utils.StringUtils;
  * // Create VET amount
  * Amount vetAmount = Amount.createFromToken(AbstractToken.VET);
  * vetAmount.setDecimalAmount("10.5");
- * System.out.println("VET: " + vetAmount.getDecimalAmount());
+ * System.out.println("VET: " + vetAmount.getAmount());
  * 
  * // Create VTHO amount
  * Amount vthoAmount = Amount.createFromToken(ERC20Token.VTHO);

--- a/src/main/java/com/vechain/thorclient/utils/BlockchainUtils.java
+++ b/src/main/java/com/vechain/thorclient/utils/BlockchainUtils.java
@@ -178,7 +178,7 @@ public class BlockchainUtils {
 	 * @param amount
 	 *            amount {@link BigDecimal}
 	 * @param precision
-	 *            must >= 0
+	 *            must &gt;= 0
 	 * @return byte array.
 	 */
 	public static byte[] byteArrayAmount(BigDecimal amount, int precision) {

--- a/src/main/java/com/vechain/thorclient/utils/CertUtils.java
+++ b/src/main/java/com/vechain/thorclient/utils/CertUtils.java
@@ -16,7 +16,7 @@ public class CertUtils {
 	/**
 	 * buildSignContent
 	 * 
-	 * @param certSha256Bytes
+	 * @param certString
 	 * @param params
 	 * @return
 	 * @throws CertificateEncodingException
@@ -121,7 +121,7 @@ public class CertUtils {
 	 * recover public key
 	 * 
 	 * @param signature
-	 * @param challengeHash
+	 * @param allMessage
 	 * @return
 	 */
 	public static String recoverPublicKey(byte[] signature, byte[] allMessage) {

--- a/src/main/java/com/vechain/thorclient/utils/RawTransactionFactory.java
+++ b/src/main/java/com/vechain/thorclient/utils/RawTransactionFactory.java
@@ -18,8 +18,8 @@ public class RawTransactionFactory {
      * @param blockRef     byte[] the first 8 bytes of the block id. Get from
      *                     {@link com.vechain.thorclient.core.model.clients.BlockRef} toByteArray().
      * @param expiration   the expiration of block size from best block to block reference.
-     * @param gasInt       must >= 21000.
-     * @param gasPriceCoef must > 0
+     * @param gasInt       must &gt;= 21000.
+     * @param gasPriceCoef must &gt; 0
      * @param nonce        eight bytes array, random by cryptography method.
      * @param toClauses    to clauses array.
      * @return {@link RawTransaction} raw transaction.
@@ -44,8 +44,8 @@ public class RawTransactionFactory {
      * @param blockRef     byte[] the first 8 bytes of the block id. Get from
      *                     {@link com.vechain.thorclient.core.model.clients.BlockRef} toByteArray().
      * @param expiration   the expiration of block size from best block to block reference.
-     * @param gasInt       must >= 21000.
-     * @param gasPriceCoef must > 0
+     * @param gasInt       must &gt;= 21000.
+     * @param gasPriceCoef must &gt; 0
      * @param nonce        eight bytes array, random by cryptography method.
      * @param rawClauses   to clauses array.
      * @return {@link RawTransaction} raw transaction.

--- a/src/main/java/com/vechain/thorclient/utils/USBKeyUtils.java
+++ b/src/main/java/com/vechain/thorclient/utils/USBKeyUtils.java
@@ -13,7 +13,7 @@ public class USBKeyUtils {
 	/**
 	 * 发送usb交易
 	 * 
-	 * @param cerHexStr
+	 * @param cert
 	 * @param txRawHash
 	 * @param privateKey
 	 * @return

--- a/src/main/java/com/vechain/thorclient/utils/merkle/MerkleTreeUtils.java
+++ b/src/main/java/com/vechain/thorclient/utils/merkle/MerkleTreeUtils.java
@@ -12,8 +12,9 @@ public class MerkleTreeUtils {
     /**
      * Build a merkle tree
      *
-     * @param leaves the {@link List< MerkleLeaf >}
-     * @return
+     * @param leaves the {@link List} of {@link MerkleLeaf}
+     * @param digest the {@link MessageDigest} used to hash nodes
+     * @return {@link MerkleTree} the built tree.
      */
     public static MerkleTree build(List<MerkleLeaf> leaves, MessageDigest digest) {
         if (leaves == null || leaves.size() == 0 || digest == null) {


### PR DESCRIPTION
Follow-ups found while working through #65 and the dependency cleanup. All small and independent.

### Javadoc build was failing
16 errors, so `MavenReportException` was reported on every build (survived only because `failOnError=false`). The `publish-javadoc` workflow deploys from that output, so gh-pages was degraded. These were real defects, not formatting nits:

- `@throws IOException` on a method that throws `ClientIOException`
- `{@link Balance}` — no such class
- `@see Amount#getDecimalAmount()` — the getter is `getAmount()`
- `@param certSha256Bytes` / `challengeHash` / `cerHexStr` — none match their parameters
- unescaped `>` in `must >= 21000`, invalid `</br>` end tags, type arguments inside `{@link List< MerkleLeaf >}`, and an `@Deprecated` tag javadoc doesn't recognise

**Now 0 errors.**

### Documented Maven coordinates didn't work
`docs/MAIN_DOCUMENTATION.md` listed `com.vechain`, but the artifact is **`com.vechain.client`** — the snippet could not resolve at all. Corrected, bumped to 0.1.1, and documented the GitHub Packages repository plus the authentication it needs. Related to #13.

### No dependabot config
There was none, which is how six Dependabot PRs went stale. Maven updates grouped weekly; `logback` majors and `blake2b` ignored because both break the Java 8 baseline. Also enables `github-actions` updates — the workflows are on `checkout@v3`/`setup-java@v3`.

### Bytecode guardrail
`enforceBytecodeVersion` with `maxJdkVersion=1.8`. **This protects the Java 8 floor, it doesn't change it** — the build fails if a *dependency* ships class files newer than Java 8.

Worth having because nothing currently catches this: `blake2b` 2.0.0 is compiled for Java 9, compiles cleanly under `-release 8`, and only fails at runtime with `UnsupportedClassVersionError` — in a consumer's application, at the point of signing a transaction. Bound to `validate` rather than `verify`, because CI runs `mvn test` and would never reach `verify`.

### Verification
- JDK 8 against thor solo: **99 tests, 0 failures**
- `mvn javadoc:javadoc`: **0 errors**
- Enforcer proven in both directions — passes on the current tree, and fails as intended when `blake2b` 2.0.0 is substituted:
  ```
  Restricted to JDK 8 yet com.rfksystems:blake2b:jar:2.0.0:compile
    contains com/rfksystems/blake2b/ByteUtils.class targeted to JDK 9
  [ERROR] Found Banned Dependency: com.rfksystems:blake2b:jar:2.0.0
  ```
