### PR TITLE
fix: make a failed subscription connect diagnosable

### DIFF
--- a/src/main/java/com/vechain/thorclient/clients/SubscribeClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/SubscribeClient.java
@@ -16,7 +16,12 @@ public class SubscribeClient extends AbstractClient {
      * Subscribe the block event.
      * @param request can be null, the best block is by default.
      * @param callback the callback instance.
-     * @return
+     * @return {@link SubscribeSocket} the subscription, possibly not connected.
+     * <p>
+     * The returned socket may not be connected if the node was unreachable;
+     * check {@link SubscribeSocket#isConnected()} and
+     * {@link SubscribeSocket#getLastError()}.
+     * </p>
      */
     public static SubscribeSocket<BlockSubscribingResponse> subscribeBlock(BlockSubscribingRequest request,
                                                  SubscribingCallback<BlockSubscribingResponse> callback) throws Exception {
@@ -29,7 +34,12 @@ public class SubscribeClient extends AbstractClient {
      * Subscribe the event log.
      * @param request the query request.
      * @param callback the callback instance.
-     * @return
+     * @return {@link SubscribeSocket} the subscription, possibly not connected.
+     * <p>
+     * The returned socket may not be connected if the node was unreachable;
+     * check {@link SubscribeSocket#isConnected()} and
+     * {@link SubscribeSocket#getLastError()}.
+     * </p>
      */
     public static SubscribeSocket<EventSubscribingResponse> subscribeEvent(EventSubscribingRequest request, SubscribingCallback<EventSubscribingResponse> callback) throws Exception {
         String url = compositeSubscribeURI(Path.GetSubEventPath.getPath(), request);
@@ -40,7 +50,12 @@ public class SubscribeClient extends AbstractClient {
      * Subscribe the transfer log.
      * @param request the query request.
      * @param callback the callback instance.
-     * @return
+     * @return {@link SubscribeSocket} the subscription, possibly not connected.
+     * <p>
+     * The returned socket may not be connected if the node was unreachable;
+     * check {@link SubscribeSocket#isConnected()} and
+     * {@link SubscribeSocket#getLastError()}.
+     * </p>
      */
     public static SubscribeSocket<TransferSubscribingResponse> subscribeTransfer(TransferSubscribingRequest request, SubscribingCallback<TransferSubscribingResponse> callback) throws Exception {
         String url = compositeSubscribeURI(Path.GetSubTransferPath.getPath(), request );

--- a/src/main/java/com/vechain/thorclient/clients/base/AbstractClient.java
+++ b/src/main/java/com/vechain/thorclient/clients/base/AbstractClient.java
@@ -203,12 +203,22 @@ public abstract class AbstractClient {
     }
 
     /**
-     * Make connection for subscription.
+     * Open a subscription connection.
+     *
+     * <p>
+     * <strong>This does not throw when the connection fails.</strong> A node that
+     * is unreachable, refuses the port, or fails the TLS handshake still yields a
+     * {@link SubscribeSocket} - one that is closed and will never deliver a
+     * callback. Callers must check {@link SubscribeSocket#isConnected()} before
+     * relying on the result, and {@link SubscribeSocket#getLastError()} reports
+     * why it failed.
+     * </p>
      *
      * @param url      long live connection url.
-     * @param callback {@link SubscribeSocket}
-     * @return {@link SubscribeSocket}
-     * @throws Exception
+     * @param callback {@link SubscribingCallback} receiving subscription events.
+     * @param <T>      type of the deserialized subscription response.
+     * @return {@link SubscribeSocket}, which may not be connected; see above.
+     * @throws Exception if the url is malformed or the arguments are invalid.
      */
     public static <T> SubscribeSocket<T> subscribeSocketConnect(String url, SubscribingCallback<T> callback)
             throws Exception {
@@ -221,7 +231,7 @@ public abstract class AbstractClient {
             if (subscribeSocket.connectBlocking(SUBSCRIBE_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 LOGGER.info("subscribeSocketConnect success: {}", url);
             } else {
-                LOGGER.error("subscribeSocketConnect failed: {}", url);
+                LOGGER.error("subscribeSocketConnect failed: {}", url, subscribeSocket.getLastError());
             }
         } catch (InterruptedException e) {
             // Restore the flag so callers up the stack can still observe the interrupt.

--- a/src/main/java/com/vechain/thorclient/clients/base/SubscribeSocket.java
+++ b/src/main/java/com/vechain/thorclient/clients/base/SubscribeSocket.java
@@ -51,6 +51,12 @@ public class SubscribeSocket<T> {
     private final Connection connection;
 
     /**
+     * Written on the WebSocket read thread, read by the thread that opened the
+     * subscription, so it must be volatile.
+     */
+    private volatile Exception lastError;
+
+    /**
      * @param serverUri the {@code ws://} or {@code wss://} subscription endpoint
      * @param callback  receives connection, message and close events
      */
@@ -71,6 +77,24 @@ public class SubscribeSocket<T> {
      */
     public boolean isConnected() {
         return connection.isOpen();
+    }
+
+    /**
+     * The most recent transport-level error, or null if none occurred.
+     *
+     * <p>
+     * A failed connect leaves the subscription closed without telling the caller
+     * why; this is where the reason ends up, typically a
+     * {@link java.net.ConnectException} for a refused port, an
+     * {@link javax.net.ssl.SSLException} for a TLS mismatch, or an
+     * {@link java.net.UnknownHostException} for a bad host. Check it whenever
+     * {@link #isConnected()} is false.
+     * </p>
+     *
+     * @return the last error reported by the WebSocket, or null
+     */
+    public Exception getLastError() {
+        return lastError;
     }
 
     /**
@@ -134,6 +158,7 @@ public class SubscribeSocket<T> {
 
         @Override
         public void onError(final Exception ex) {
+            lastError = ex;
             LOGGER.error("Subscription error", ex);
         }
     }

--- a/src/test/java/com/vechain/thorclient/clients/SubscribeSocketFailureTest.java
+++ b/src/test/java/com/vechain/thorclient/clients/SubscribeSocketFailureTest.java
@@ -1,0 +1,87 @@
+package com.vechain.thorclient.clients;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.vechain.thorclient.base.BaseTest;
+import com.vechain.thorclient.clients.base.AbstractClient;
+import com.vechain.thorclient.clients.base.SubscribeSocket;
+import com.vechain.thorclient.clients.base.SubscribingCallback;
+import com.vechain.thorclient.core.model.blockchain.BlockSubscribingResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * subscribeSocketConnect deliberately does not throw when the node is
+ * unreachable; it returns a closed subscription. These tests pin that contract
+ * and prove the reason is recoverable rather than silently swallowed.
+ */
+@RunWith(JUnit4.class)
+public class SubscribeSocketFailureTest extends BaseTest {
+
+    /** Port chosen so nothing is listening; the connect must be refused. */
+    private static final String UNREACHABLE = "ws://127.0.0.1:1/subscriptions/block";
+
+    private SubscribingCallback<BlockSubscribingResponse> noopCallback() {
+        return new SubscribingCallback<BlockSubscribingResponse>() {
+            @Override
+            public void onClose(int statusCode, String reason) {
+            }
+
+            @Override
+            public void onConnect(SubscribeSocket<BlockSubscribingResponse> socket) {
+                Assert.fail("onConnect must not fire for an unreachable node");
+            }
+
+            @Override
+            public Class<BlockSubscribingResponse> responseClass() {
+                return BlockSubscribingResponse.class;
+            }
+
+            @Override
+            public void onSubscribe(BlockSubscribingResponse response) throws JsonProcessingException {
+                Assert.fail("onSubscribe must not fire for an unreachable node");
+            }
+        };
+    }
+
+    @Test
+    public void failedConnectReturnsAClosedSocketRatherThanThrowing() throws Exception {
+        final SubscribeSocket<BlockSubscribingResponse> socket =
+                AbstractClient.subscribeSocketConnect(UNREACHABLE, noopCallback());
+
+        Assert.assertNotNull("a socket is still returned on failure", socket);
+        Assert.assertFalse("socket must report itself as not connected", socket.isConnected());
+    }
+
+    /**
+     * Regression: the failure reason used to be logged and discarded, leaving
+     * callers unable to tell a refused port from a TLS or DNS problem.
+     */
+    @Test
+    public void failedConnectExposesTheUnderlyingCause() throws Exception {
+        final SubscribeSocket<BlockSubscribingResponse> socket =
+                AbstractClient.subscribeSocketConnect(UNREACHABLE, noopCallback());
+
+        final Exception cause = socket.getLastError();
+        Assert.assertNotNull("the connect failure reason must be recoverable", cause);
+        logger.info("recovered connect failure: {}: {}",
+                cause.getClass().getName(), cause.getMessage());
+    }
+
+    @Test
+    public void invalidArgumentsStillThrow() {
+        try {
+            AbstractClient.subscribeSocketConnect("  ", noopCallback());
+            Assert.fail("blank url must be rejected");
+        } catch (Exception expected) {
+            // argument validation is a caller error and remains an exception
+        }
+        try {
+            AbstractClient.subscribeSocketConnect(UNREACHABLE, null);
+            Assert.fail("null callback must be rejected");
+        } catch (Exception expected) {
+            // as above
+        }
+    }
+}


### PR DESCRIPTION
`subscribeSocketConnect` does not throw when the node is unreachable — it returns a **closed** `SubscribeSocket`. That behaviour is deliberately kept, since callers already depend on it. The problem was that the reason was logged and thrown away, so a caller seeing `isConnected() == false` had no way to distinguish a refused port from a TLS or DNS failure.

**Changes** — purely additive, no signature or behaviour changes:

- `SubscribeSocket.getLastError()` exposes the exception Java-WebSocket reports. The field is `volatile`: written on the read thread, read by the thread that opened the subscription.
- `AbstractClient` logs that cause on a failed connect rather than just the url.
- Documents the contract, which was previously unstated, on `subscribeSocketConnect` and the three `SubscribeClient` entry points: **the returned socket may not be connected** — check `isConnected()`, then `getLastError()`.
- Corrects the `@param` on `subscribeSocketConnect`, which described `callback` as a `SubscribeSocket` rather than a `SubscribingCallback`.

**Verification**

- JDK 8 against thor solo: **102 tests, 0 failures**
- The new test connects to a dead port and recovers the real cause:
  ```
  recovered connect failure: java.net.ConnectException: Connection refused
  ```
- Confirmed it fails without the fix — removing the capture gives
  `AssertionError: the connect failure reason must be recoverable`
- Introduces no javadoc errors (16 on this branch, 16 on master; #77 clears them)
