### PR TITLE
ci: restore packages:write, run CI on every PR, and smoke test the jar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,14 @@ updates:
           - minor
           - patch
     ignore:
-      # Pinned to the Java 8 line. logback 1.5+ and 1.6+ require Java 11, so a
-      # major bump here would silently break the SDK's baseline.
+      # Pinned to the 1.3.x line, which is the last to target Java 8; 1.4 and
+      # above require Java 11. These are minor bumps, not major, so ignoring
+      # only semver-major let logback 1.6.1 through and the build guard had to
+      # catch it. Allow patches within 1.3.x and nothing else.
       - dependency-name: "ch.qos.logback:*"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       # 2.0.0 is compiled for Java 9 and cannot load on Java 8. It also derives
       # VeChain transaction IDs, so any bump needs known-answer hash vectors.
       - dependency-name: "com.rfksystems:blake2b"

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -3,8 +3,19 @@ name: Java CI with Maven
 on:
   push:
     branches: [ master ]
+  # Deliberately unfiltered by base branch. With `branches: [master]` a stacked
+  # pull request got no CI at all until its parent merged and it retargeted,
+  # which meant reviewing changes nothing had built.
   pull_request:
-    branches: [ master ]
+  workflow_dispatch:
+
+# A force-push should cancel the run it supersedes rather than queue behind it.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -22,9 +33,27 @@ jobs:
     - name: Start thor solo
       run:  make solo-up
       id: start-solo
-    - name: Run tests with Maven
+    # `package`, not `test`: this also builds the shaded jar so the smoke test
+    # below has something to run.
+    - name: Build and run tests with Maven
       id: run-tests
-      run: mvn -B test
+      run: mvn -B package
+    # The shaded jar crashed at startup with "Invalid signature file digest" for
+    # months without CI noticing, because nothing ever ran the jar it built.
+    # Note the CLI exits 0 even when a command fails, so the assertion is on
+    # output rather than exit status.
+    - name: Smoke test the runnable jar against solo
+      id: smoke-test
+      run: |
+        set -euo pipefail
+        JAR=$(ls target/*-with-dependencies.jar)
+        echo "Smoke testing $JAR"
+        OUTPUT=$(java -jar "$JAR" getChainTag http://localhost:8669 2>&1) || true
+        echo "$OUTPUT"
+        if ! echo "$OUTPUT" | grep -qE '^0x[0-9a-f]{2}$'; then
+          echo "::error::Runnable jar did not return a chain tag; the CLI is broken."
+          exit 1
+        fi
     - name: Stop thor solo
       id: stop-solo
       if: always()

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,12 +4,20 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: publish-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy-release:
     runs-on: ubuntu-latest
 
     permissions:
+      # contents: write to upload the release asset; packages: write for the
+      # GitHub Packages deploy. Naming any scope sets every other to none, so
+      # both must be listed explicitly.
       contents: write
+      packages: write
 
     steps:
       - name: Checkout code
@@ -31,11 +39,8 @@ jobs:
           echo "Using version $TAG_NAME"
           mvn versions:set -DnewVersion=$TAG_NAME
 
-      - name: Build Release jar
-        run: mvn clean package -Pall
-
-      - name: Deploy Release to GitHub Packages
-        run: mvn deploy -Pall
+      - name: Build and deploy Release to GitHub Packages
+        run: mvn clean deploy -Pall
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,3 +54,7 @@ jobs:
 
       - name: Stop solo
         run: make solo-down  
+
+  publish-javadoc:
+    needs: build-and-deploy-release
+    uses: ./.github/workflows/publish-javadoc.yml

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,9 +6,18 @@ on:
       - master
   workflow_dispatch:
 
+# Two quick pushes to master would otherwise race each other's uploads.
+concurrency:
+  group: publish-snapshot
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy-snapshot:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Fixes a regression I introduced in #77, plus the CI gaps that let two bugs reach master unnoticed.

### Regression from #77 — release deploy would have failed
#77 added `permissions: contents: write` to `publish-release`. **Naming any scope sets every other to `none`**, so `packages: write` was silently revoked and the next `mvn deploy` to GitHub Packages would have failed with 401. Not observed yet only because no release has been cut since. Both scopes are now explicit.

### CI never ran on stacked PRs
`pull_request: branches: [master]` meant a PR based on another branch got **no build at all** until its parent merged and it retargeted — #74 and #75 were reviewed before anything had built them. The base filter is removed.

### CI never ran the jar it built
The shaded jar crashed at startup with `Invalid signature file digest` for months (fixed in #74) because nothing executed the build output. CI now runs a real command through the jar against solo:

```
Smoke testing target/thor-client-sdk4j-...-with-dependencies.jar
ChainTag:
0x58
```

The assertion is on **output, not exit status** — the console catches exceptions and still exits 0, so an exit-code check would happily pass against a dead node.

### Dependabot ignore was too narrow
It ignored `semver-major` for logback, but 1.3.16 → 1.6.1 is a **minor** bump, so Dependabot proposed the Java 11 line and the bytecode guard had to reject it (#80). Only 1.3.x patches are Java 8 safe, so minor is now ignored too.

### Smaller tidy-ups
- `publish-release` ran `package` then `deploy`, executing the full suite against solo **twice**; now one `deploy`
- javadoc is published on release, not just on snapshot, so the docs site reflects the released version
- concurrency groups so pushes can't race each other's uploads
- least-privilege `permissions` on the remaining workflows

### Verification
- JDK 8 against solo: **99 tests pass**, enforcer passes, smoke test returns `0x58`
- **Proved the smoke test works**: reverting the base shade config to its pre-#74 state rebuilds the broken jar, which fails with `SecurityException: Invalid signature file digest`, and the smoke test correctly fails the build
