### PR TITLE
fix(ci): restore javadoc publishing broken by the plugin bump in #83

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -24,6 +24,20 @@ jobs:
       - name: Build Javadoc
         run: mvn javadoc:javadoc
 
+      # peaceiris/actions-gh-pages reports a missing publish_dir as
+      # "a branch named 'gh-pages' already exists", which says nothing about the
+      # real cause. Fail here instead, where the message is actionable.
+      - name: Verify javadoc output exists
+        run: |
+          set -euo pipefail
+          DIR=target/site/apidocs
+          if [ ! -f "$DIR/index.html" ]; then
+            echo "::error::No javadoc at $DIR. The maven-javadoc-plugin output directory has moved; check outputDirectory in pom.xml."
+            find target -name index.html -path '*apidocs*' -print 2>/dev/null || true
+            exit 1
+          fi
+          echo "Javadoc present: $(find "$DIR" -name '*.html' | wc -l) html files"
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,12 @@
                 <configuration>
                     <failOnError>false</failOnError>
                     <failOnWarnings>false</failOnWarnings>
+                    <!-- Pinned because the default moved: 3.6.x wrote to target/site/apidocs,
+                         while 3.12.0 defaults outputDirectory to target/reports. publish-javadoc.yml
+                         deploys a fixed path, so the plugin bump in #83 left it publishing a
+                         directory that no longer existed and gh-pages deployment broke. Setting this
+                         explicitly keeps the location stable across plugin versions. -->
+                    <outputDirectory>${project.build.directory}/site</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Build & Publish Snapshot has failed on every master push since #83 merged** ([run 31703636851](https://github.com/vechain/thor-client-sdk4j/actions/runs/31703636851)). The snapshot deploy itself succeeds; the `publish-javadoc` job fails.

### Cause

`maven-javadoc-plugin` 3.6.3 wrote to `target/site/apidocs`. 3.12.0 defaults `outputDirectory` to `${project.build.directory}/reports`, so it now writes to `target/reports/apidocs`. `publish-javadoc.yml` deploys a hardcoded `./target/site/apidocs`, which no longer exists.

`peaceiris/actions-gh-pages` reports a missing `publish_dir` as:

```
fatal: a branch named 'gh-pages' already exists
```

which points nowhere near the real problem.

### Fix

- **Pin `outputDirectory`** to `${project.build.directory}/site` so the location is stable across plugin versions, rather than tracking a default that has now moved once and could move again.
- **Check before deploying**, so a relocated javadoc directory fails with an actionable message that prints where the output actually went.

### Verification

- javadoc builds **367 html files into `target/site/apidocs`**; `reports/apidocs` empty
- **102 tests pass** on JDK 8, enforcer passes, javadoc jar still attaches, smoke test returns `0x58`
- Removing the pin reproduces the failure, and the new check catches it:

```
::error::No javadoc at target/site/apidocs. The maven-javadoc-plugin output directory has moved
    found instead: target/reports/apidocs/index.html
```

### Note

This was my miss when vetting #83. I verified the bump kept javadoc at **0 errors** but never checked *where the output went* — the wrong property. `failOnError=false` meant the build stayed green either way.
